### PR TITLE
Create ecosystem service credit spec

### DIFF
--- a/docs/specs/ecosystem-service-credit.md
+++ b/docs/specs/ecosystem-service-credit.md
@@ -56,7 +56,7 @@ type MsgConsumeCredit struct {
 type []byte OfferID
 
 type ManageCreditOffer struct {
-  Credit CreditID
+  Credits []CreditID
   Account sdk.AccAddress
   // Units should be set to 0 to delete an offer
   Units sdk.Dec
@@ -81,6 +81,17 @@ type MsgManageCreditClassBuyOffer struct {
   // Units should be set to 0 to delete an offer
   Units sdk.Dec
   CoinsPerUnit sdk.Coins
+  // Offer should be set to nil to create a new offer
+  Offer OfferID
+}
+
+type MsgManageCreditClassExchangeOffer struct {
+  SellCredits []CreditID
+  BuyCreditClass CreditClassID
+  Account sdk.AccAddress
+  // Units should be set to 0 to delete an offer
+  SellUnits sdk.Dec
+  BuyUnits sdk.Dec
   // Offer should be set to nil to create a new offer
   Offer OfferID
 }

--- a/docs/specs/ecosystem-service-credit.md
+++ b/docs/specs/ecosystem-service-credit.md
@@ -52,6 +52,8 @@ type MsgConsumeCredit struct {
 
 ## Credit Exchange
 
+### Buying and Selling Credits with Coins
+
 ```go
 type []byte OfferID
 
@@ -84,6 +86,14 @@ type MsgManageCreditClassBuyOffer struct {
   // Offer should be set to nil to create a new offer
   Offer OfferID
 }
+```
+
+### Exchanging Credits of Different Classes
+
+This would effectively allow credits of a single class to be treated as an 
+effectively fungible asset and allow trading pairs between two credit classes.
+
+```go
 
 type MsgManageCreditClassExchangeOffer struct {
   SellCredits []CreditID

--- a/docs/specs/ecosystem-service-credit.md
+++ b/docs/specs/ecosystem-service-credit.md
@@ -12,6 +12,8 @@ type []byte CreditClassID
 type MsgIssueCredit struct {
   CreditClass CreditClassID 
   Polygon geo.Polygon
+  StartDate time.Time
+  EndDate time.Time
   Issuer sdk.AccAddress
   Vendor sdk.AccAddress
 }

--- a/docs/specs/ecosystem-service-credit.md
+++ b/docs/specs/ecosystem-service-credit.md
@@ -23,7 +23,7 @@ type []byte CreditClassID
 // overlaps with those of an existing credit of the same class 
 type MsgIssueCredit struct {
   CreditClass CreditClassID 
-  Polygon geo.Polygon
+  Polygon geo.GeoAddress
   StartDate time.Time
   EndDate time.Time
   // Units specifies how many total units of this credit are issued for this polygon
@@ -54,63 +54,5 @@ type MsgConsumeCredit struct {
   Credit CreditID
   Holder sdk.AccAddress
   Units sdk.Dec
-}
-```
-
-
-## Credit Exchange
-
-### Buying and Selling Credits with Coins
-
-```go
-type []byte OfferID
-
-type ManageCreditOffer struct {
-  Credits []CreditID
-  Account sdk.AccAddress
-  // Units should be set to 0 to delete an offer
-  Units sdk.Dec
-  CoinsPerUnit sdk.Coins
-  // Offer should be set to nil to create a new offer
-  Offer OfferID
-}
-
-type MsgManageCreditSellOffer struct {
-  ManageCreditOffer
-}
-
-type MsgManageCreditBuyOffer struct {
-  ManageCreditOffer
-}
-
-// MsgManageCreditClassBuyOffer can be used to generically buy credits of a
-// given class irregardless of the specific credit being purchased
-type MsgManageCreditClassBuyOffer struct {
-  CreditClass CreditClassID
-  Account sdk.AccAddress
-  // Units should be set to 0 to delete an offer
-  Units sdk.Dec
-  CoinsPerUnit sdk.Coins
-  // Offer should be set to nil to create a new offer
-  Offer OfferID
-}
-```
-
-### Exchanging Credits of Different Classes
-
-This would effectively allow credits of a single class to be treated as an 
-effectively fungible asset and allow trading pairs between two credit classes.
-
-```go
-
-type MsgManageCreditClassExchangeOffer struct {
-  SellCredits []CreditID
-  BuyCreditClass CreditClassID
-  Account sdk.AccAddress
-  // Units should be set to 0 to delete an offer
-  SellUnits sdk.Dec
-  BuyUnits sdk.Dec
-  // Offer should be set to nil to create a new offer
-  Offer OfferID
 }
 ```

--- a/docs/specs/ecosystem-service-credit.md
+++ b/docs/specs/ecosystem-service-credit.md
@@ -72,4 +72,16 @@ type MsgManageCreditSellOffer struct {
 type MsgManageCreditBuyOffer struct {
   ManageCreditOffer
 }
+
+// MsgManageCreditClassBuyOffer can be used to generically buy credits of a
+// given class irregardless of the specific credit being purchased
+type MsgManageCreditClassBuyOffer struct {
+  CreditClass CreditClassID
+  Account sdk.AccAddress
+  // Units should be set to 0 to delete an offer
+  Units sdk.Dec
+  CoinsPerUnit sdk.Coins
+  // Offer should be set to nil to create a new offer
+  Offer OfferID
+}
 ```

--- a/docs/specs/ecosystem-service-credit.md
+++ b/docs/specs/ecosystem-service-credit.md
@@ -1,6 +1,9 @@
 # Messages
 
+## Credit Issuance, Transfer and Consumption
+
 ```go
+// MsgCreateCreditClass creates a class of credits and returns a new CreditClassID
 type MsgCreateCreditClass struct {
   Curator sdk.AccAddress
   Name string
@@ -9,35 +12,64 @@ type MsgCreateCreditClass struct {
 
 type []byte CreditClassID
 
+// MsgIssueCredit issues a credit to the Holder with the number of Units provided
+// for the provided credit class, polygon, and start and end dates. A new CreditID
+// is returned. It is illegal to issue a credit where the provided polygon and dates
+// overlaps with those of an existing credit of the same class 
 type MsgIssueCredit struct {
   CreditClass CreditClassID 
   Polygon geo.Polygon
   StartDate time.Time
   EndDate time.Time
+  Units sdk.Dec
   Issuer sdk.AccAddress
-  Vendor sdk.AccAddress
+  Holder sdk.AccAddress
 }
 
 type []byte CreditID
 
-type MsgAssignCredit struct {
+// MsgSendCredit sends the provided number of units of the credit from the from
+// address to the to address
+type MsgSendCredit struct {
   Credit CreditID
-  Vendor sdk.AccAddress
-  Offsetter sdk.AccAddress
-  SquareMeters sdk.Dec
+  From sdk.AccAddress
+  To sdk.AccAddress
+  Units sdk.Dec
 }
 
-type MsgOfferCredit struct {
+// MsgConsumeCredit consumes the provided number of units of the credit, essentially
+// burning or retiring those units. This operation is used to actually use
+// the credit as an offset. Otherwise, the holder of the credit is simply
+// holding the credit as an asset but has not claimed the offset. Once a
+// credit has been consumed, it can no longer be transferred
+type MsgConsumeCredit struct {
   Credit CreditID
-  Vendor sdk.AccAddress
-  MaxSquareMeters sdk.Dec
-  CoinsPerSquareMeter sdk.Coins
+  Holder sdk.AccAddress
+  Units sdk.Dec
+}
+```
+
+
+## Credit Exchange
+
+```go
+type []byte OfferID
+
+type ManageCreditOffer struct {
+  Credit CreditID
+  Account sdk.AccAddress
+  // Units should be set to 0 to delete an offer
+  Units sdk.Dec
+  CoinsPerUnit sdk.Coins
+  // Offer should be set to nil to create a new offer
+  Offer OfferID
 }
 
-type MsgBuyCredit struct {
-  Credit CreditID
-  SquareMeters sdk.Dec
-  Buyer sdk.AccAddress
-  Coins sdk.Coins
+type MsgManageCreditSellOffer struct {
+  ManageCreditOffer
+}
+
+type MsgManageCreditBuyOffer struct {
+  ManageCreditOffer
 }
 ```

--- a/docs/specs/ecosystem-service-credit.md
+++ b/docs/specs/ecosystem-service-credit.md
@@ -5,8 +5,13 @@
 ```go
 // MsgCreateCreditClass creates a class of credits and returns a new CreditClassID
 type MsgCreateCreditClass struct {
-  Curator sdk.AccAddress
+  // Designer is the entity which designs a credit class at the top-level and
+  // certifies issuers
+  Designer sdk.AccAddress
+  // Name is the name the Designer gives to the credit, internally credits
+  // are identified by their CreditClassID
   Name string
+  // Issuers are those entities authorized to issue credits via MsgIssueCredit
   Issuers []sdk.AccAddress
 }
 
@@ -21,8 +26,11 @@ type MsgIssueCredit struct {
   Polygon geo.Polygon
   StartDate time.Time
   EndDate time.Time
+  // Units specifies how many total units of this credit are issued for this polygon
   Units sdk.Dec
   Issuer sdk.AccAddress
+  // Holder receives the credit from the issuer and can send it to other holders
+  // or consume it
   Holder sdk.AccAddress
 }
 

--- a/docs/specs/ecosystem-service-credit.md
+++ b/docs/specs/ecosystem-service-credit.md
@@ -1,0 +1,41 @@
+# Messages
+
+```go
+type MsgCreateCreditClass struct {
+  Curator sdk.AccAddress
+  Name string
+  Issuers []sdk.AccAddress
+}
+
+type []byte CreditClassID
+
+type MsgIssueCredit struct {
+  CreditClass CreditClassID 
+  Polygon geo.Polygon
+  Issuer sdk.AccAddress
+  Vendor sdk.AccAddress
+}
+
+type []byte CreditID
+
+type MsgAssignCredit struct {
+  Credit CreditID
+  Vendor sdk.AccAddress
+  Offsetter sdk.AccAddress
+  SquareMeters sdk.Dec
+}
+
+type MsgOfferCredit struct {
+  Credit CreditID
+  Vendor sdk.AccAddress
+  MaxSquareMeters sdk.Dec
+  CoinsPerSquareMeter sdk.Coins
+}
+
+type MsgBuyCredit struct {
+  Credit CreditID
+  SquareMeters sdk.Dec
+  Buyer sdk.AccAddress
+  Coins sdk.Coins
+}
+```


### PR DESCRIPTION
This PR creates a specification for ecosystem service credits - a form of non-fungible token (NFT) that has uniqueness constraints around geolocation, time, and credit type to prevent double issuance of credits for the same location and the same time.

Let us use this PR as a forum to discuss the design of this functionality.