### PR TITLE
Amazonas upgrade

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -104,7 +104,7 @@ type XrnApp struct {
 	keyFeeCollection *sdk.KVStoreKey
 	keyParams        *sdk.KVStoreKey
 	tkeyParams       *sdk.TransientStoreKey
-	upgradeStoreKey    *sdk.KVStoreKey
+	upgradeStoreKey  *sdk.KVStoreKey
 	//dataStoreKey       *sdk.KVStoreKey
 	//schemaStoreKey     *sdk.KVStoreKey
 	//espStoreKey        *sdk.KVStoreKey
@@ -168,7 +168,7 @@ func NewXrnApp(logger log.Logger, db dbm.DB, traceStore io.Writer, loadLatest bo
 		keyFeeCollection: sdk.NewKVStoreKey(auth.FeeStoreKey),
 		keyParams:        sdk.NewKVStoreKey(params.StoreKey),
 		tkeyParams:       sdk.NewTransientStoreKey(params.TStoreKey),
-		upgradeStoreKey:    sdk.NewKVStoreKey(upgrade.StoreKey),
+		upgradeStoreKey:  sdk.NewKVStoreKey(upgrade.StoreKey),
 		//dataStoreKey:       sdk.NewKVStoreKey("data"),
 		//schemaStoreKey:     sdk.NewKVStoreKey("schema"),
 		//espStoreKey:        sdk.NewKVStoreKey("esp"),
@@ -204,7 +204,7 @@ func NewXrnApp(logger log.Logger, db dbm.DB, traceStore io.Writer, loadLatest bo
 		app.bankKeeper, app.feeCollectionKeeper)
 	app.upgradeKeeper = upgrade.NewKeeper(app.upgradeStoreKey, app.cdc)
 	// this configures a no-op upgrade handler for the "el-choco" upgrade
-	app.upgradeKeeper.SetUpgradeHandler("el-choco", func(ctx sdk.Context, plan upgrade.Plan) { })
+	app.upgradeKeeper.SetUpgradeHandler("amazonas", func(ctx sdk.Context, plan upgrade.Plan) {})
 
 	// register the proposal types
 	govRouter := gov.NewRouter()

--- a/app/app.go
+++ b/app/app.go
@@ -204,7 +204,13 @@ func NewXrnApp(logger log.Logger, db dbm.DB, traceStore io.Writer, loadLatest bo
 		app.bankKeeper, app.feeCollectionKeeper)
 	app.upgradeKeeper = upgrade.NewKeeper(app.upgradeStoreKey, app.cdc)
 	// this configures a no-op upgrade handler for the "el-choco" upgrade
-	app.upgradeKeeper.SetUpgradeHandler("amazonas", func(ctx sdk.Context, plan upgrade.Plan) {})
+	app.upgradeKeeper.SetUpgradeHandler("amazonas", func(ctx sdk.Context, plan upgrade.Plan) {
+		// Add some more coins to the faucet account
+		addr, err := sdk.AccAddressFromBech32("xrn:1xrsmkqh305m09tc5x73v4t3wtcuqmf6cgy2taw")
+		if err == nil {
+			_, _ = app.bankKeeper.AddCoins(ctx, addr, sdk.Coins{sdk.Coin{Denom: "tree", Amount: sdk.NewInt(10000000)}})
+		}
+	})
 
 	// register the proposal types
 	govRouter := gov.NewRouter()

--- a/go.mod
+++ b/go.mod
@@ -45,4 +45,4 @@ require (
 
 replace golang.org/x/crypto => github.com/tendermint/crypto v0.0.0-20180820045704-3764759f34a5
 
-replace github.com/cosmos/cosmos-sdk => github.com/regen-network/cosmos-sdk v0.0.0-0.20190329021654-1b7a69be1993054a17a71d905d2b4df15ffec3f8
+replace github.com/cosmos/cosmos-sdk => github.com/regen-network/cosmos-sdk v0.0.0-0.20190329021654-281da889de6ca3c7784d5570fd95de78d7d23a59

--- a/go.sum
+++ b/go.sum
@@ -194,6 +194,8 @@ github.com/regen-network/cosmos-sdk v0.0.0-0.20190329021654-13fdf0c499fa0ef8ff9f
 github.com/regen-network/cosmos-sdk v0.0.0-0.20190329021654-13fdf0c499fa0ef8ff9f303999f43fa8eb582211/go.mod h1:aLgIheIE6TNKv6nyUhMjLwS4QHntAcEzgZzJBINvTds=
 github.com/regen-network/cosmos-sdk v0.0.0-0.20190329021654-1b7a69be1993054a17a71d905d2b4df15ffec3f8 h1:PHRwj/13QcrR5F+5Z6YwBEh5hPhoaYvCW+u8UwB6etA=
 github.com/regen-network/cosmos-sdk v0.0.0-0.20190329021654-1b7a69be1993054a17a71d905d2b4df15ffec3f8/go.mod h1:BvyNPEYewihHQa092/+OEX5dgLZsV7H2boKkkj1H2wI=
+github.com/regen-network/cosmos-sdk v0.0.0-0.20190329021654-281da889de6ca3c7784d5570fd95de78d7d23a59 h1:tv1w/7CktlBOMrFVW53qrRPO2jC3gmz69QkUxfFI7hc=
+github.com/regen-network/cosmos-sdk v0.0.0-0.20190329021654-281da889de6ca3c7784d5570fd95de78d7d23a59/go.mod h1:BvyNPEYewihHQa092/+OEX5dgLZsV7H2boKkkj1H2wI=
 github.com/regen-network/cosmos-sdk v0.0.0-0.20190329021654-2aca2a23f319f7415479009b57b6d27c9113c422 h1:geHDeOMbcg8jZetkR7k0yW6FvTKmY0qFo38W/ImmRMk=
 github.com/regen-network/cosmos-sdk v0.0.0-0.20190329021654-2aca2a23f319f7415479009b57b6d27c9113c422/go.mod h1:BvyNPEYewihHQa092/+OEX5dgLZsV7H2boKkkj1H2wI=
 github.com/regen-network/cosmos-sdk v0.0.0-0.20190329021654-40bbfbc157c4086e61ee284716d9da0b8b361458 h1:M4dUjBPotvaPFbnas69qMYBfIkffejaRcqmJKhy2dX4=


### PR DESCRIPTION
Adds an upgrade handler for the `amazonas` upgrade and upgrades the Cosmos SDK fork to the latest regen-network/upgrade-module-v0.4 branch