### PR TITLE
Update changelog for v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2021-04-13
+
+This release is the version of regen-ledger that will be used for the mainnet launch of Regen Network's blockchain (chain-id: `regen-1`).
+
+It enables configurable builds for regen ledger (by building with an `EXPERIMENTAL=true/false` build flag). With this new configuration, we've made the following delineation.
+
+* Stable build (EXPERIMENTAL=false) is intended for Regen Network's mainnet, and any testing networks aiming to replicate the mainnet configuration.
+  * Includes all standard modules from the Cosmos SDK (bank/staking/gov/etc.), as well as IBC
+* Experimental builds, are intended to have more experimental features which have not gone through a full internal audit and are intended for devnets and 3rd party developers who want to work on integrating with future features of regen ledger.
+  * In addition to stable build modules, experimental build includes:
+    * Regen specific modules (x/ecocredit, x/data)
+    * CosmWasm
+    * x/group
+
+It is not guaranteed that APIs of features in the experimental build will remain consistent until they are migrated to the stable configuration.
+
+### Added
+* make configurable builds (#256)
+
+### Changed
+* Upgrade to Cosmos SDK v0.42.4
+
+## [0.6.0] - 2021-02-04
+
+This release contains first iterations of the `x/ecocredit` and `x/data` modules which were launched in a Devnet as part of the Open Climate Collabathon in Nov 2020. 
+
+It is more or less a full rewrite of regen-ledger to upgrade it to Stargate (Cosmos SDK v0.40)
+
+It also includes an initial draft of the `x/group` module for on-chain multisig and DAO use cases.
+
+### Added
+
+* Data Module Proof of Consept (#118)
+* Eco-Credit Module Proof of Concept (#119)
+* Addition of vuepress docs site: docs.regen.network (#158)
+* Add CosmWasm module to regen ledger (#148)
+* Add group module (#154)
+
+
+### Changed
+
+* Custom protobuf service codegen (#207)
+* Update to SDK v0.40.0 (#219)
+* Remove usage/naming of `gaia` / `XrnApp` / `simd`
+
+## [0.5.0] - 2019-09-21
+
+This release provides the amazonas test upgrade the regen-test-1001 testnet. Specifically this release packages the following changes to the upgrade module:
+
+when an upgrade is planned, the new binary which contains code for the planned upgrade will panic if it is started too early
+upgrade scripts are disabled because they were glitchy to setup and not recommended
+
 ## [0.4.0] - 2019-06-04
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,13 @@ It is not guaranteed that APIs of features in the experimental build will remain
 
 ### Added
 * make configurable builds (#256)
+* add remaining group events
+* add group module documentation (#314)
 
 ### Changed
-* Upgrade to Cosmos SDK v0.42.4
+* upgrade to Cosmos SDK v0.42.4
+* update group tx commands
+* remove colon from regen addresses
 
 ## [0.6.0] - 2021-02-04
 


### PR DESCRIPTION
Update changelog for v1.0.0, as well as missing entries for v0.5.0 and v0.6.0.

Moving forward we should get back into a good changelog practice of having entries with each PR in the [UNRELEASED] stanza.

`v1.0.0` will be tagged and published off of this merge commit.