### PR TITLE
fix: parse key freezes

### DIFF
--- a/app/addr_prefixes.go
+++ b/app/addr_prefixes.go
@@ -37,4 +37,5 @@ func init() {
 		}
 		return fmt.Errorf("unexpected address length %d", n)
 	})
+	config.Seal()
 }


### PR DESCRIPTION
Came up during PR review on SDK [ref](https://github.com/cosmos/cosmos-sdk/blob/master/types/address.go#L28-L34).