### PR TITLE
feat: Create x/curation module data model and tx API

### DIFF
--- a/proto/regen/curation/v1/tx.proto
+++ b/proto/regen/curation/v1/tx.proto
@@ -1,0 +1,132 @@
+syntax = "proto3";
+package regen.curation.v1;
+
+option go_package = "github.com/regen-network/regen-ledger/x/curation";
+
+// Msg is the regen.curation.v1 Msg service.
+service Msg {
+    // CreateTagSet creates a new tag set with the provided metadata and returns an auto-generated tag set ID.
+    rpc CreateTagSet(MsgCreateTagSet) returns (MsgCreateTagSetResponse) {}
+
+    // CreateTag creates a new tag in a tag set with the provided metadata and returns an auto-generated tag ID.
+    rpc CreateTag(MsgCreateTag) returns (MsgCreateTagResponse) {}
+
+    // TagAsset associates a tag with an asset denom.
+    rpc TagAsset(MsgTagAsset) returns (MsgTagAssetResponse) {}
+
+    // TagAsset associates a tag with a whole class of assets identified by the asset denom prefix.
+    rpc TagAssetClass(MsgTagAssetClass) returns (MsgTagAssetClassResponse) {}
+
+    // EditTagSetMetadata edits a tag set's metadata.
+    rpc EditTagSetMetadata(MsgEditTagSetMetadata) returns (MsgEditTagSetMetadataReponse) {}
+
+    // ChangeTagSetMaintainer changes the maintainer of a tag set.
+    rpc ChangeTagSetMaintainer(MsgChangeTagSetMaintainer) returns (MsgChangeTagSetMaintainerResponse) {}
+
+    // EditTagMetadata edits a tag's metadata.
+    rpc EditTagMetadata(MsgEditTagMetadata) returns (MsgEditTagMetadataReponse) {}
+}
+
+// MsgCreateTagSet is the Msg/CreateTagSet request type.
+message MsgCreateTagSet {
+    // maintainer is the address of the tag set maintainer.
+    string maintainer = 1;
+
+    // name is an optional human readable name of the tag set.
+    string name = 2;
+
+    // description is an optional human readable description of the tag set.
+    string description = 3;
+
+    // uri is an optional URI/URL describing the tag set.
+    string uri = 4;
+}
+
+// MsgCreateTagSetResponse is the Msg/CreateTagSetResponse response type.
+message MsgCreateTagSetResponse {
+    // tag_set_id is the auto-generated ID of the tag set.
+    string tag_set_id = 1;
+}
+
+// MsgCreateTag is the Msg/CreateTag request type.
+message MsgCreateTag {
+    // maintainer is the address of the tag set maintainer.
+    string maintainer = 1;
+
+    // tag_set_id is the ID of the tag set within which this tag should be created.
+    string tag_set_id = 2;
+
+    // name is an optional human readable name of the tag .
+    string name = 3;
+
+    // description is an optional human readable description of the tag.
+    string description = 4;
+
+    // uri is an optional URI/URL describing the tag.
+    string uri = 5;
+}
+
+// MsgCreateTagResponse is the MsgCreateTagResponse response type.
+message MsgCreateTagResponse {
+    // tag_id is the auto-generated ID of the tag. It is always prefixed by the tag set ID for the tag
+    // set within which it was created and a `/` character.
+    string tag_id = 1;
+}
+
+// MsgTagAsset is the Msg/TagAsset request type.
+message MsgTagAsset {
+    // maintainer is the address of the tag's maintainer (this is always the same as the tag set's maintainer).
+    string maintainer = 1;
+
+    // tag_id is the ID of the tag.
+    string tag_id = 2;
+
+    // denom is the denom of the asset.
+    string denom = 3;
+}
+
+// MsgTagAssetResponse is the Msg/TagAssetResponse response type.
+message MsgTagAssetResponse { }
+
+message MsgTagAssetClass {
+    // maintainer is the address of the tag's maintainer (this is always the same as the tag set's maintainer).
+    string maintainer = 1;
+
+    // tag_id is the ID of the tag.
+    string tag_id = 2;
+
+    // denom_prefix is the prefix of denom's in this asset class. This could correspond to a credit class prefix which
+    // is always the prefix of all credit batches issued within this class. This provides a way to tag whole classes of
+    // credits or NFTs.
+    string denom_prefix = 3;
+}
+
+message MsgTagAssetClassResponse { }
+
+message MsgEditTagSetMetadata {
+    string maintainer = 1;
+    string tag_set_id = 2;
+    string name = 3;
+    string description = 4;
+    string uri = 5;
+}
+
+message MsgEditTagSetMetadataReponse { }
+
+message MsgChangeTagSetMaintainer {
+    string maintainer = 1;
+    string tag_set_id = 2;
+    string new_maintainer = 3;
+}
+
+message MsgChangeTagSetMaintainerResponse { }
+
+message MsgEditTagMetadata {
+    string maintainer = 1;
+    string tag_id = 2;
+    string name = 3;
+    string description = 4;
+    string uri = 5;
+}
+
+message MsgEditTagMetadataReponse { }


### PR DESCRIPTION
ref: #374

I had some ideas in my head on this so wanted to get them down. This proposes an API for the `x/curation` module as proposed in #374.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)