### PR TITLE
feat(x/ecocredit)!: remove basket multiplier and simplify picking

### DIFF
--- a/proto/regen/ecocredit/v1alpha2/tx.proto
+++ b/proto/regen/ecocredit/v1alpha2/tx.proto
@@ -77,8 +77,8 @@ service Msg {
   //   so on.
   rpc TakeFromBasket(MsgTakeFromBasket) returns (MsgTakeFromBasketResponse);
 
-  // PickFromBasket picks specific credits from a basket. It will fail if
-  // allow_picking is false at the basket level. The credits will be
+  // PickFromBasket picks specific credits from a basket for a fee. It will fail
+  // if allow_picking is false at the basket level. The credits will be
   // auto-retired unless disable_auto_retire is set to true on both the Msg and
   // basket level.
   rpc PickFromBasket(MsgPickFromBasket) returns (MsgPickFromBasketResponse);
@@ -591,6 +591,10 @@ message MsgPickFromBasket {
   // disable_auto_retire allows credits to be taken without retiring them. It
   // can only be used if disable_auto_retire is set on the basket level.
   bool disable_auto_retire = 5;
+
+  // fee is the fee that the user will pay for picking credits. It must be equal
+  // to or greater than the network enforced fee for this operation.
+  cosmos.base.v1beta1.Coin fee = 6;
 }
 
 message MsgPickFromBasketResponse {}

--- a/proto/regen/ecocredit/v1alpha2/tx.proto
+++ b/proto/regen/ecocredit/v1alpha2/tx.proto
@@ -64,8 +64,9 @@ service Msg {
   rpc AddToBasket(MsgAddToBasket) returns (MsgAddToBasketResponse);
 
   // TakeFromBasket takes credits from a basket without regard for which
-  // credits they are. The credits will be auto-retired if retire_on_take
-  // is true. Credits will be chosen randomly using the previous block hash
+  // credits they are. The credits will be auto-retired unless
+  // disable_auto_retire is set to true on both the Msg and basket level.
+  // Credits will be chosen randomly using the previous block hash
   // as a consensus source of randomness.
   // More concretely, the implementation is as follows:
   // - take the previous block hash and convert it into an uint64,
@@ -76,16 +77,10 @@ service Msg {
   //   so on.
   rpc TakeFromBasket(MsgTakeFromBasket) returns (MsgTakeFromBasketResponse);
 
-  // PickFromBasket picks specific credits from a basket. If allow_picking is
-  // set to false, then only an address which deposited credits in the basket
-  // can pick those credits. All other addresses will be blocked from picking
-  // those credits. The credits will be auto-retired if retire_on_take is
-  // true unless the credits were previously put into the basket by the
-  // address picking them from the basket, in which case they will remain
-  // tradable. This functionality allows the owner of a credit to have more
-  // control over the credits they are putting in baskets then ordinary users
-  // to deal with the scenario where basket tokens end up being worth
-  // significantly less than the credits on their own.
+  // PickFromBasket picks specific credits from a basket. It will fail if
+  // allow_picking is false at the basket level. The credits will be
+  // auto-retired unless disable_auto_retire is set to true on both the Msg and
+  // basket level.
   rpc PickFromBasket(MsgPickFromBasket) returns (MsgPickFromBasketResponse);
 }
 
@@ -519,30 +514,24 @@ message MsgCreateBasket {
   // basket token of the form ecocredit:{curator}:{display_name}.
   string display_name = 3;
 
-  // exponent is the exponent that will be used for denom metadata. An exponent
-  // of 6 will mean that 10^6 units of a basket token should be displayed
-  // as one unit in user interfaces.
+  // exponent is the exponent that will be used for converting credits to basket
+  // units as well as for denom metadata. An exponent of 6 will mean that 10^6
+  // units of a basket token should be issued for every 1.0 credits. If there
+  // are any fractional amounts left over in this calculation when adding
+  // credits to a basket, those fractional amounts will not get added to the
+  // basket.
   uint32 exponent = 4;
 
-  // basket_criteria is the criteria by which credits can be added to the
-  // basket. Basket criteria will be applied in order and the first criteria
-  // which applies to a credit will determine its multiplier in the basket.
-  repeated BasketCriteria basket_criteria = 5;
+  Filter filter = 5;
 
-  bool disable_auto_retire = 6;
+  // credit_type_name is the type of credits this basket will allow. Baskets can
+  // only hold one type of credit (ex. carbon) and all filter criteria will be
+  // applied within this credit type.
+  string credit_type_name = 6;
 
-  bool allow_picking = 7;
-}
+  bool disable_auto_retire = 7;
 
-message BasketCriteria {
-  Filter filter = 1;
-
-  // multiplier is an integer number which is applied to credit units when
-  // converting to basket units. For example if the multiplier is 2000, then
-  // 1.1 credits will result in 2200 basket tokens. If there are any fractional
-  // amounts left over in this calculation when adding credits to a basket,
-  // those fractional amounts will not get added to the basket.
-  string multiplier = 2;
+  bool allow_picking = 8;
 }
 
 message MsgCreateBasketResponse {
@@ -573,9 +562,12 @@ message MsgTakeFromBasket {
 
   string amount = 3;
 
-  // retirement_location is the optional retirement location for the credits
-  // which will be used only if retire_on_take is true for this basket.
+  // retirement_location is the optional retirement location for the credits.
   string retirement_location = 4;
+
+  // disable_auto_retire allows credits to be taken without retiring them. It
+  // can only be used if disable_auto_retire is set on the basket level.
+  bool disable_auto_retire = 5;
 }
 
 message MsgTakeFromBasketResponse {
@@ -593,9 +585,12 @@ message MsgPickFromBasket {
   // credits are the units of credits being picked from the basket
   repeated BasketCredit credits = 3;
 
-  // retirement_location is the optional retirement location for the credits
-  // which will be used only if retire_on_take is true for this basket.
+  // retirement_location is the optional retirement location for the credits.
   string retirement_location = 4;
+
+  // disable_auto_retire allows credits to be taken without retiring them. It
+  // can only be used if disable_auto_retire is set on the basket level.
+  bool disable_auto_retire = 5;
 }
 
 message MsgPickFromBasketResponse {}

--- a/proto/regen/ecocredit/v1alpha2/types.proto
+++ b/proto/regen/ecocredit/v1alpha2/types.proto
@@ -230,23 +230,22 @@ message Filter {
     And and = 1;
     Or or = 2;
 
-    string credit_type_name = 3;
-    string class_id = 4;
+    string class_id = 3;
 
     // project_id filters against credits from this batch.
-    string project_id = 5;
+    string project_id = 4;
 
     // batch_id filters against credits from this batch.
-    string batch_denom = 6;
+    string batch_denom = 5;
 
     // class_admin filters against credits issued by this class admin.
-    string class_admin = 7;
+    string class_admin = 6;
 
     // issuer filters against credits issued by this issuer address.
-    string issuer = 8;
+    string issuer = 7;
 
     // owner filters against credits currently owned by this address.
-    string owner = 9;
+    string owner = 8;
 
     // project_location can be specified in three levels of granularity:
     // country, sub-national-code, or postal code. If just country is given,
@@ -254,12 +253,12 @@ message Filter {
     // their project location is more specific, ex. "US-NY 12345". If
     // a country, sub-national-code and postal code are all provided then
     // only projects in that postal code will match.
-    string project_location = 10;
+    string project_location = 9;
 
-    DateRange date_range = 11;
+    DateRange date_range = 10;
 
     // tag specifies a curation tag to match against.
-    string tag = 12;
+    string tag = 11;
   }
 
   message And {


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #641 #640 

This PR:
* removes differential multipliers from baskets
* enforces that baskets can only contain one credit type (ex. "carbon" or "biodiversity" but not both)
* specifies that allow picking either allows everyone to pick or nobody
* adds a fee for picking operations
* fixes some issues with disable_auto_retire semantics

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)