### PR TITLE
fix(ecocredit): use `open` field when creating batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#1274](https://github.com/regen-network/regen-ledger/pull/1274) Add `cancel-sell-order` command
 
+#### Fixed
+- [#1278](https://github.com/regen-network/regen-ledger/pull/1278) Fix `open` not set in `Msg/CreateBatch`
+
 ## [v4.0.0-rc1](https://github.com/regen-network/regen-ledger/releases/tag/v4.0.0-rc1) - 2022-07-15
 
 ### General

--- a/x/ecocredit/server/core/features/msg_create_batch.feature
+++ b/x/ecocredit/server/core/features/msg_create_batch.feature
@@ -347,7 +347,8 @@ Feature: Msg/CreateBatch
         "project_id": "C01-001",
         "metadata": "regen:13toVfvC2YxrrfSXWB5h2BGHiXZURsKxWUz72uDRDSPMCrYPguGUXSC.rdf",
         "start_date": "2020-01-01T00:00:00Z",
-        "end_date": "2021-01-01T00:00:00Z"
+        "end_date": "2021-01-01T00:00:00Z",
+        "open": true
       }
       """
       Then expect batch properties
@@ -356,7 +357,8 @@ Feature: Msg/CreateBatch
         "denom": "C01-001-20200101-20210101-001",
         "metadata": "regen:13toVfvC2YxrrfSXWB5h2BGHiXZURsKxWUz72uDRDSPMCrYPguGUXSC.rdf",
         "start_date": "2020-01-01T00:00:00Z",
-        "end_date": "2021-01-01T00:00:00Z"
+        "end_date": "2021-01-01T00:00:00Z",
+        "open": true
       }
       """
 

--- a/x/ecocredit/server/core/msg_create_batch.go
+++ b/x/ecocredit/server/core/msg_create_batch.go
@@ -54,13 +54,14 @@ func (k Keeper) CreateBatch(ctx context.Context, req *core.MsgCreateBatch) (*cor
 	startDate, endDate := timestamppb.New(*req.StartDate), timestamppb.New(*req.EndDate)
 	issuanceDate := timestamppb.New(sdkCtx.BlockTime())
 	batchKey, err := k.stateStore.BatchTable().InsertReturningID(ctx, &api.Batch{
-		ProjectKey:   project.Key,
 		Issuer:       issuer,
+		ProjectKey:   project.Key,
 		Denom:        batchDenom,
 		Metadata:     req.Metadata,
 		StartDate:    startDate,
 		EndDate:      endDate,
 		IssuanceDate: issuanceDate,
+		Open:         req.Open,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

- fixes a bug where the `open` field was not used from the request in `CreateBatch`
- updates test to include the `open` property set to `true`

Closes: n/a

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)