### PR TITLE
fix(types): return nil duration and timestamp

### DIFF
--- a/types/timestamp.go
+++ b/types/timestamp.go
@@ -13,7 +13,7 @@ import (
 // GogoToProtobufTimestamp converts a gogo timestamp to a protobuf timestamp.
 func GogoToProtobufTimestamp(ts *gogotypes.Timestamp) *timestamppb.Timestamp {
 	if ts == nil {
-		return &timestamppb.Timestamp{}
+		return nil
 	}
 	return &timestamppb.Timestamp{
 		Seconds: ts.Seconds,
@@ -24,7 +24,7 @@ func GogoToProtobufTimestamp(ts *gogotypes.Timestamp) *timestamppb.Timestamp {
 // ProtobufToGogoTimestamp converts a protobuf timestamp to a gogo timestamp.
 func ProtobufToGogoTimestamp(ts *timestamppb.Timestamp) *gogotypes.Timestamp {
 	if ts == nil {
-		return &gogotypes.Timestamp{}
+		return nil
 	}
 	return &gogotypes.Timestamp{
 		Seconds: ts.Seconds,
@@ -35,7 +35,7 @@ func ProtobufToGogoTimestamp(ts *timestamppb.Timestamp) *gogotypes.Timestamp {
 // GogoToProtobufDuration converts a gogo duration to a protobuf duration.
 func GogoToProtobufDuration(d *gogotypes.Duration) *durationpb.Duration {
 	if d == nil {
-		return &durationpb.Duration{}
+		return nil
 	}
 	return &durationpb.Duration{
 		Seconds: d.Seconds,

--- a/types/timestamp_test.go
+++ b/types/timestamp_test.go
@@ -30,7 +30,7 @@ func TestGogoToProtobufDuration(t *testing.T) {
 		{
 			name: "nil case",
 			args: args{d: nil},
-			want: &durationpb.Duration{},
+			want: nil,
 		},
 	}
 	for _, tt := range tests {
@@ -59,7 +59,7 @@ func TestGogoToProtobufTimestamp(t *testing.T) {
 		{
 			name: "nil",
 			args: args{ts: nil},
-			want: &timestamppb.Timestamp{},
+			want: nil,
 		},
 	}
 	for _, tt := range tests {
@@ -88,7 +88,7 @@ func TestProtobufToGogoTimestamp(t *testing.T) {
 		{
 			name: "nil",
 			args: args{ts: nil},
-			want: &gogotypes.Timestamp{},
+			want: nil,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #1272

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

Manual tests: https://hackmd.io/ioZPdD22REaHBE1YQg1YPg

This pull request updates timestamp conversion functions to return `nil` if timestamp or duration is `nil` rather than returning the zero-value timestamp and duration. This only affects query responses where a timestamp or duration is used and where these values are not required when being added to state (e.g. sell order expiration). This will also use `nil` rather than the zero-value timestamp for issuance date when querying batches if a batch is added between now and the upgrade.

For example, a sell order with no expiration previously returned:

```
sell_order:
  ask_amount: "1000000"
  ask_denom: stake
  batch_denom: C01-001-20200101-20210101-001
  disable_auto_retire: true
  expiration: "2023-01-01T00:00:00Z"
  id: "1"
  quantity: "100"
  seller: regen1mjj52fal48xsj2q3yypguzwuqccxfr3larwezy
```

Now, a sell order with no expiration returns:

```
sell_order:
  ask_amount: "1000000"
  ask_denom: stake
  batch_denom: C01-001-20200101-20210101-001
  disable_auto_retire: true
  expiration: null
  id: "2"
  quantity: "100"
  seller: regen1mjj52fal48xsj2q3yypguzwuqccxfr3larwezy
```

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)