### PR TITLE
docs: opening a new terminal isn't necessary

### DIFF
--- a/docs/ledger/get-started/README.md
+++ b/docs/ledger/get-started/README.md
@@ -86,7 +86,7 @@ Move the binary to your local bin directory:
 sudo mv regen-ledger_4.0.0_linux_amd64/regen /usr/local/bin
 ```
 
-Open a new terminal window and check if the installation was successful:
+Check if the installation was successful:
 
 ```bash
 regen version


### PR DESCRIPTION
## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

In the Linux section, the last step to run 'regen version' doesn't seem to require opening a new terminal. I was able to do this in the same session. This is a small change but I thought it would just make it a little be clearer.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct `docs:` prefix in the PR title
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [x] followed the [documentation writing guidelines](https://github.com/cosmos/cosmos-sdk/blob/main/docs/DOC_WRITING_GUIDELINES.md)
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [x] confirmed the correct `docs:` prefix in the PR title
- [ ] confirmed all author checklist items have been addressed 
- [x] confirmed that this PR only changes documentation
- [ ] reviewed content for consistency
- [ ] reviewed content for thoroughness
- [ ] reviewed content for spelling and grammar
- [x] tested instructions (if applicable)
