### PR TITLE
feat(x/ecocredit): add retirement reason flag

### DIFF
--- a/x/ecocredit/base/client/tx.go
+++ b/x/ecocredit/base/client/tx.go
@@ -20,9 +20,11 @@ import (
 
 const (
 	FlagAddIssuers             string = "add-issuers"
+	FlagReason                 string = "reason"
 	FlagRemoveIssuers          string = "remove-issuers"
 	FlagReferenceID            string = "reference-id"
 	FlagRetirementJurisdiction string = "retirement-jurisdiction"
+	FlagRetirementReason       string = "retirement-reason"
 	FlagClassFee               string = "class-fee"
 )
 
@@ -244,21 +246,18 @@ Example JSON:
   "issuance": [
     {
       "recipient": "regen1elq7ys34gpkj3jyvqee0h6yk4h9wsfxmgqelsw",
-      "tradable_amount": "1000",
-      "retired_amount": "500",
-      "retirement_jurisdiction": "US-WA"
+      "tradable_amount": "1000"
     },
     {
       "recipient": "regen1depk54cuajgkzea6zpgkq36tnjwdzv4ak663u6",
-      "tradable_amount": "1000",
-      "retired_amount": "500",
-      "retirement_jurisdiction": "US-OR"
+      "retired_amount": "1000",
+      "retirement_jurisdiction": "US-OR",
+      "retirement_reason": "offsetting electricity consumption"
     }
   ],
   "metadata": "regen:13toVgf5UjYBz6J29x28pLQyjKz5FpcW3f4bT5uRKGxGREWGKjEdXYG.rdf",
   "start_date": "2020-01-01T00:00:00Z",
-  "end_date": "2021-01-01T00:00:00Z",
-  "open": false
+  "end_date": "2021-01-01T00:00:00Z"
 }`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -305,31 +304,46 @@ Parameters:
 			if err != nil {
 				return err
 			}
+
 			retireTo, err := cmd.Flags().GetString(FlagRetirementJurisdiction)
 			if err != nil {
 				return err
 			}
+
 			tradableAmount := args[0]
+
 			retiredAmount := "0"
 			if len(retireTo) > 0 {
 				tradableAmount = "0"
 				retiredAmount = args[0]
 			}
+
+			reason, err := cmd.Flags().GetString(FlagRetirementReason)
+			if err != nil {
+				return err
+			}
+
 			credit := types.MsgSend_SendCredits{
 				TradableAmount:         tradableAmount,
 				BatchDenom:             args[1],
 				RetiredAmount:          retiredAmount,
 				RetirementJurisdiction: retireTo,
+				RetirementReason:       reason,
 			}
+
 			msg := types.MsgSend{
 				Sender:    clientCtx.GetFromAddress().String(),
 				Recipient: args[2],
 				Credits:   []*types.MsgSend_SendCredits{&credit},
 			}
+
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), &msg)
 		},
 	}
+
 	cmd.Flags().String(FlagRetirementJurisdiction, "", "Jurisdiction to retire the credits to. If empty, credits are not retired. (default empty)")
+	cmd.Flags().String(FlagRetirementReason, "", "the reason for retiring the credits (optional)")
+
 	return txFlags(cmd)
 }
 
@@ -358,7 +372,8 @@ Example JSON:
     "batch_denom": "C01-001-20200101-20210101-002",
     "tradable_amount": "50",
     "retired_amount": "100",
-    "retirement_jurisdiction": "YY-ZZ 12345"
+    "retirement_jurisdiction": "YY-ZZ 12345",
+    "retirement_reason": "offsetting electricity consumption"
   }
 ]`,
 		Args: cobra.ExactArgs(2),
@@ -425,15 +440,23 @@ Example JSON:
 				return sdkerrors.ErrInvalidRequest.Wrapf("failed to parse json: %s", err)
 			}
 
+			reason, err := cmd.Flags().GetString(FlagRetirementReason)
+			if err != nil {
+				return err
+			}
+
 			msg := types.MsgRetire{
 				Owner:        clientCtx.GetFromAddress().String(),
 				Credits:      credits,
 				Jurisdiction: args[1],
+				Reason:       reason,
 			}
 
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), &msg)
 		},
 	}
+
+	cmd.Flags().String(FlagReason, "", "the reason for retiring the credits (optional)")
 
 	return txFlags(cmd)
 }

--- a/x/ecocredit/basket/client/tx.go
+++ b/x/ecocredit/basket/client/tx.go
@@ -26,6 +26,7 @@ const (
 	FlagBasketFee              = "basket-fee"
 	FlagDenomDescription       = "description"
 	FlagRetirementJurisdiction = "retirement-jurisdiction"
+	FlagRetirementReason       = "retirement-reason"
 	FlagRetireOnTake           = "retire-on-take"
 )
 
@@ -182,14 +183,14 @@ Parameters:
 Example JSON:
 
 [
-	{
-		"batch_denom": "C01-001-20210101-20220101-001",
-		"amount": "10"
-	},
-	{
-		"batch_denom": "C01-001-20210101-20220101-001",
-		"amount": "10.5"
-	}
+  {
+    "batch_denom": "C01-001-20210101-20220101-001",
+    "amount": "10"
+  },
+  {
+    "batch_denom": "C01-001-20210101-20220101-001",
+    "amount": "10.5"
+  }
 ]`,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -253,6 +254,11 @@ regen tx ecocredit take-from-basket eco.uC.NCT 1000 --retire-on-take=true --reti
 				return err
 			}
 
+			retirementReason, err := cmd.Flags().GetString(FlagRetirementReason)
+			if err != nil {
+				return err
+			}
+
 			retireOnTake, err := cmd.Flags().GetBool(FlagRetireOnTake)
 			if err != nil {
 				return err
@@ -263,6 +269,7 @@ regen tx ecocredit take-from-basket eco.uC.NCT 1000 --retire-on-take=true --reti
 				BasketDenom:            args[0],
 				Amount:                 args[1],
 				RetirementJurisdiction: retirementJurisdiction,
+				RetirementReason:       retirementReason,
 				RetireOnTake:           retireOnTake,
 			}
 
@@ -275,6 +282,7 @@ regen tx ecocredit take-from-basket eco.uC.NCT 1000 --retire-on-take=true --reti
 	}
 
 	cmd.Flags().String(FlagRetirementJurisdiction, "", "jurisdiction for the credits which will be used only if --retire-on-take flag is true")
+	cmd.Flags().String(FlagRetirementReason, "", "the reason for retiring the credits (optional)")
 	cmd.Flags().Bool(FlagRetireOnTake, false, "dictates whether the ecocredits received in exchange for the basket tokens will be received as retired or tradable credits")
 
 	return txFlags(cmd)

--- a/x/ecocredit/marketplace/client/tx.go
+++ b/x/ecocredit/marketplace/client/tx.go
@@ -16,6 +16,7 @@ import (
 
 const (
 	FlagRetirementJurisdiction = "retirement-jurisdiction"
+	FlagRetirementReason       = "retirement-reason"
 )
 
 // TxSellCmd returns a transaction command that creates sell orders.
@@ -98,8 +99,8 @@ Example JSON:
     "new_quantity": "5",
     "new_ask_price": {
       "denom": "uregen",
-      "amount" "100000000"
-	},
+      "amount": "100000000"
+    },
     "disable_auto_retire": true
   },
   {
@@ -107,8 +108,8 @@ Example JSON:
     "new_quantity": "10",
     "new_ask_price": {
       "denom": "uregen",
-      "amount" "100000000"
-	},
+      "amount": "100000000"
+    },
     "disable_auto_retire": false,
     "new_expiration": "2024-01-01T00:00:00Z"
   }
@@ -175,8 +176,12 @@ NOTE: The bid price is the price paid PER credit. The total cost will be quantit
 				return err
 			}
 
-			var retireJurisdiction string
-			retireJurisdiction, err = cmd.Flags().GetString(FlagRetirementJurisdiction)
+			retireJurisdiction, err := cmd.Flags().GetString(FlagRetirementJurisdiction)
+			if err != nil {
+				return err
+			}
+
+			retireReason, err := cmd.Flags().GetString(FlagRetirementReason)
 			if err != nil {
 				return err
 			}
@@ -190,6 +195,7 @@ NOTE: The bid price is the price paid PER credit. The total cost will be quantit
 						BidPrice:               &bidPrice,
 						DisableAutoRetire:      disableAutoRetire,
 						RetirementJurisdiction: retireJurisdiction,
+						RetirementReason:       retireReason,
 					},
 				},
 			}
@@ -199,6 +205,7 @@ NOTE: The bid price is the price paid PER credit. The total cost will be quantit
 	}
 
 	cmd.Flags().String(FlagRetirementJurisdiction, "", "the jurisdiction to use for retirement when auto retire is true.")
+	cmd.Flags().String(FlagRetirementReason, "", "the reason for retiring the credits (optional)")
 
 	return txFlags(cmd)
 }
@@ -226,8 +233,7 @@ Example JSON:
       "denom": "uregen",
       "amount": "32000000"
     },
-    "disable_auto_retire": false,
-    "retirement_jurisdiction": "US-NY"
+    "disable_auto_retire": true
   },
   {
     "sell_order_id": 2,
@@ -237,7 +243,8 @@ Example JSON:
       "amount": "32000000"
     },
     "disable_auto_retire": false,
-    "retirement_jurisdiction": "US-NY"
+    "retirement_jurisdiction": "US-NY",
+    "retirement_reason": "offsetting electricity consumption"
   }
 ]`,
 		Args: cobra.ExactArgs(1),


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Ref: https://hackmd.io/vcNbk99BTiWJ4cMtALSBOA

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This pull request add an optional retirement reason flag to all tx commands that support retirement reason.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)