### PR TITLE
docs: Fix broken link in architecture.md

### DIFF
--- a/docs/ledger/architecture.md
+++ b/docs/ledger/architecture.md
@@ -6,7 +6,7 @@ Regen Ledger is a proof-of-stake blockchain application built on top of [Cosmos 
 
 Much of the language and usage patterns when interacting with Regen Ledger follow directly from the usage patterns and architecture laid out in Cosmos SDK.
 
-For more information about Cosmos SDK and what it means to build an "application specific blockchain", the [Cosmos SDK Documentation](https://docs.cosmos.network/main/intro/overview.html#what-are-application-specific-blockchains) is a great place to start.
+For more information about Cosmos SDK and what it means to build an "application specific blockchain", the [Cosmos SDK Documentation](https://docs.cosmos.network/main/learn/intro/why-app-specific) is a great place to start.
 
 ## Regen Ledger
 


### PR DESCRIPTION
## Description

The deeplink to the cosmos SDK was obsolete

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct `docs:` prefix in the PR title
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [x] followed the [documentation writing guidelines](https://github.com/cosmos/cosmos-sdk/blob/main/docs/DOC_WRITING_GUIDELINES.md)
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct `docs:` prefix in the PR title
- [ ] confirmed all author checklist items have been addressed 
- [ ] confirmed that this PR only changes documentation
- [ ] reviewed content for consistency
- [ ] reviewed content for thoroughness
- [ ] reviewed content for spelling and grammar
- [ ] tested instructions (if applicable)
