### PR TITLE
chore: return nil instead of error directly

### DIFF
--- a/x/data/client/util.go
+++ b/x/data/client/util.go
@@ -31,7 +31,7 @@ func mkQueryClient(cmd *cobra.Command) (data.QueryClient, client.Context, error)
 	if err != nil {
 		return nil, client.Context{}, err
 	}
-	return data.NewQueryClient(ctx), ctx, err
+	return data.NewQueryClient(ctx), ctx, nil
 }
 
 func parseContentHash(clientCtx client.Context, filePath string) (*data.ContentHash, error) {

--- a/x/ecocredit/base/client/utils.go
+++ b/x/ecocredit/base/client/utils.go
@@ -38,7 +38,7 @@ func mkQueryClient(cmd *cobra.Command) (types.QueryClient, sdkclient.Context, er
 	if err != nil {
 		return nil, sdkclient.Context{}, err
 	}
-	return types.NewQueryClient(ctx), ctx, err
+	return types.NewQueryClient(ctx), ctx, nil
 }
 
 func parseMsgCreateBatch(clientCtx sdkclient.Context, jsonFile string) (*types.MsgCreateBatch, error) {


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

The return value err here must be nil. So we can return nil instead of error directly to make it more clearly.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)