### PR TITLE
docs: add OpenChainBench live RPC latency benchmark link

### DIFF
--- a/docs/ledger/get-started/regen-mainnet.md
+++ b/docs/ledger/get-started/regen-mainnet.md
@@ -17,6 +17,7 @@ The following RPC endpoints are for full nodes operated by RND and VitWit:
 The following RPC endpoint is for an archive node operated by RND:
 
 - [http://archive.regen.network:26657/](http://archive.regen.network:26657/)
+- [OpenChainBench live latency benchmark](https://openchainbench.com/benchmarks/regen-rpc) — independent p50/p90/p99 measurements for free Regen RPC endpoints, updated every 60 s
 
 ## Configuration
 


### PR DESCRIPTION
Adds a reference to [OpenChainBench](https://openchainbench.com/benchmarks/regen-rpc) in the Node Endpoints section.

OpenChainBench continuously probes free public Regen RPC endpoints and publishes independent p50/p90/p99 latency measurements updated every 60 seconds. Useful for developers and validators choosing or verifying an RPC endpoint.